### PR TITLE
Add getToolRelations method to TagsCalendar and TagsGeometry

### DIFF
--- a/TagsCalendar/public/js/main.js
+++ b/TagsCalendar/public/js/main.js
@@ -15,6 +15,10 @@ var TagsCalendar = (function() {
             });
         };
 
+        self.getToolRelations = function () {
+            return {KGquery: "queryToTagsCalendar"}
+        }
+
         self.drawSparqlResultTimeLine = function(sparqlresult) {
 
             self.sparqlresult = sparqlresult;

--- a/TagsGeometry/public/js/main.js
+++ b/TagsGeometry/public/js/main.js
@@ -10,6 +10,10 @@ var TagsGeometry = (function() {
         self.config = config
     }
 
+    self.getToolRelations = function () {
+        return {KGquery: "queryToTagsGeometry"}
+    }
+
     self.onLoaded = function() {
 
 


### PR DESCRIPTION
Store the relation with sls tools in plugin.

related to https://github.com/souslesens/souslesensVocables/pull/785 and https://github.com/souslesens/souslesensVocables/issues/777
